### PR TITLE
Mark message as unread.

### DIFF
--- a/src/knowledgebase/chatbot/chatbot.controller.ts
+++ b/src/knowledgebase/chatbot/chatbot.controller.ts
@@ -16,6 +16,7 @@ import { RequestWithUser } from '../../common/@types/nest.types';
 import { ChatSessionSparse } from '../knowledgebase.schema';
 import {
   ChatbotQueryDTO,
+  ChatMarkAsUnreadDTO,
   CreateChatbotSessionDTO,
   PromptTestDTO,
   UpdateChatbotSessionDTO,
@@ -84,6 +85,17 @@ export class ChatbotController {
   @Post('/test_prompt')
   async testPrompt(@Body() data: PromptTestDTO) {
     return this.chatbotService.testPrompt(data);
+  }
+
+  @Public()
+  @Post('/session/:sessionId/unread')
+  @HttpCode(200)
+  async markMessageAsUnread(
+    @Req() req: RequestWithUser,
+    @Param('sessionId') sessionId: string,
+    @Body() data: ChatMarkAsUnreadDTO,
+  ) {
+    return this.chatbotService.markMessageAsUnread(sessionId, data.ts);
   }
 
   @Post('/demo_session')

--- a/src/knowledgebase/chatbot/chatbot.dto.ts
+++ b/src/knowledgebase/chatbot/chatbot.dto.ts
@@ -25,6 +25,12 @@ export class ChatbotQueryDTO {
   query: string;
 }
 
+export class ChatMarkAsUnreadDTO {
+  @IsString()
+  @IsNotEmpty()
+  ts: string;
+}
+
 export class PromptTestDTO {
   @IsString()
   @IsOptional()

--- a/src/knowledgebase/chatbot/chatbot.service.ts
+++ b/src/knowledgebase/chatbot/chatbot.service.ts
@@ -38,6 +38,7 @@ import { OpenaiChatbotService } from './openaiChatbotService';
 const CHAT_SESION_EXPIRY_TIME = 5 * 60;
 const CHUNK_FILTER_THRESHOLD = 0.3;
 const SOURCES_FILTER_THRESHOLD = 0.8;
+// const EPOCH = '2000-01-01T00:00:00.000+00:00';
 
 @Injectable()
 export class ChatbotService {
@@ -108,6 +109,7 @@ export class ChatbotService {
         session.knowledgebaseId,
         totalTokens,
       ),
+      this.markSessionAsRead(session._id),
     ]);
   }
 
@@ -245,6 +247,7 @@ export class ChatbotService {
         qTokens: 0,
         aTokens: 0,
         ts: new Date(),
+        read: true,
       };
       await this.updateSessionDataWithNewMsg(sessionData, msg);
       return answer;
@@ -288,6 +291,7 @@ export class ChatbotService {
       qTokens: answer.tokenUsage.prompt,
       aTokens: answer.tokenUsage.completion,
       ts: new Date(),
+      read: true,
     };
     await this.updateSessionDataWithNewMsg(sessionData, msg);
 
@@ -332,6 +336,7 @@ export class ChatbotService {
         qTokens: 0,
         aTokens: 0,
         ts: new Date(),
+        read: true,
       };
       await this.updateSessionDataWithNewMsg(sessionData, msg);
       return of(answer);
@@ -370,6 +375,7 @@ export class ChatbotService {
           qTokens: usage.prompt,
           aTokens: usage.completion,
           ts: new Date(),
+          read: true,
         };
         await this.updateSessionDataWithNewMsg(sessionData, msg);
 
@@ -583,5 +589,24 @@ export class ChatbotService {
       pageSize,
       page,
     );
+  }
+
+  async markSessionAsRead(sessionId: ObjectId) {
+    try {
+      this.kbDbService.markMessageAsRead(sessionId, new Date().toISOString());
+    } catch {
+      throw new HttpException('Invalid Session', HttpStatus.NOT_FOUND);
+    }
+  }
+
+  async markMessageAsUnread(sessionId: string, ts: string) {
+    try {
+      if (ts == undefined) {
+        ts = new Date().toISOString();
+      }
+      this.kbDbService.markMessageAsUnread(new ObjectId(sessionId), ts);
+    } catch {
+      throw new HttpException('Invalid Session', HttpStatus.NOT_FOUND);
+    }
   }
 }

--- a/src/knowledgebase/chatbot/chatbot.service.ts
+++ b/src/knowledgebase/chatbot/chatbot.service.ts
@@ -38,7 +38,6 @@ import { OpenaiChatbotService } from './openaiChatbotService';
 const CHAT_SESION_EXPIRY_TIME = 5 * 60;
 const CHUNK_FILTER_THRESHOLD = 0.3;
 const SOURCES_FILTER_THRESHOLD = 0.8;
-// const EPOCH = '2000-01-01T00:00:00.000+00:00';
 
 @Injectable()
 export class ChatbotService {

--- a/src/knowledgebase/knowledgebase-db.service.ts
+++ b/src/knowledgebase/knowledgebase-db.service.ts
@@ -489,7 +489,31 @@ export class KnowledgebaseDbService {
   async addMsgToChatSession(id: ObjectId, msg: ChatQueryAnswer) {
     await this.chatSessionCollection.updateOne(
       { _id: id },
-      { $push: { messages: msg }, $set: { updatedAt: new Date() } },
+      { $push: { messages: msg }, $set: { updatedAt: new Date(), read: true } },
+    );
+  }
+
+  async markMessageAsUnread(sessionId: ObjectId, ts: string) {
+    await this.chatSessionCollection.updateMany(
+      {
+        _id: sessionId,
+      },
+      { $set: { 'messages.$[element].read': false } },
+      {
+        arrayFilters: [{ 'element.ts': { $gte: new Date(ts) } }],
+      },
+    );
+  }
+
+  async markMessageAsRead(sessionId: ObjectId, ts: string) {
+    await this.chatSessionCollection.updateMany(
+      {
+        _id: sessionId,
+      },
+      { $set: { 'messages.$[element].read': true } },
+      {
+        arrayFilters: [{ 'element.ts': { $lte: new Date(ts) } }],
+      },
     );
   }
 

--- a/src/knowledgebase/knowledgebase.schema.ts
+++ b/src/knowledgebase/knowledgebase.schema.ts
@@ -138,6 +138,7 @@ export interface ChatQueryAnswer {
   qTokens: number;
   aTokens: number;
   ts: Date;
+  read: boolean;
 }
 
 export const CHAT_SESSION_COLLECTION = 'chatSessions';


### PR DESCRIPTION
In this request, a new API is exposed: {{base_url}}/chatbot/session/{{sessionId}}/unread that can take in a payload that looks like:
```
{
    "ts": "2023-09-04T03:38:25.372+00:00"
}
```
This will mark all the messages in that session after this time as unread.

Also all the messages in a session will be marked as read when generating a new answer.