### PR TITLE
Change Pricing based on Message count

### DIFF
--- a/frontend/src/components/Pricing/FreeComponent.tsx
+++ b/frontend/src/components/Pricing/FreeComponent.tsx
@@ -49,7 +49,7 @@ export const FreeComponent = ({ currentSubscription, discountData, userEmail,  a
                 subscriptionData={{
                     type: 'AppSumo tier 1',
                     pageCount: 2000,
-                    messagecount: '1k',
+                    messageCount: '1k',
                     tokenSize: '1M',
                     projectCount: 20,
                 }}
@@ -64,7 +64,7 @@ export const FreeComponent = ({ currentSubscription, discountData, userEmail,  a
                 subscriptionData={{
                     type: 'AppSumo tier 2',
                     pageCount: 5000,
-                    messagecount: '2.5k',
+                    messageCount: '2.5k',
                     tokenSize: '2.5M',
                     projectCount: 50,
                 }}
@@ -79,7 +79,7 @@ export const FreeComponent = ({ currentSubscription, discountData, userEmail,  a
                 subscriptionData={{
                     type: 'AppSumo tier 3',
                     pageCount: 10000,
-                    messagecount: '5K',
+                    messageCount: '5K',
                     tokenSize: '5M',
                     projectCount: 'Unlimited',
                 }}
@@ -218,7 +218,7 @@ export const FreeComponent = ({ currentSubscription, discountData, userEmail,  a
                                 pageCount: 100,
                                 tokenSize: '400K',
                                 projectCount: 5,
-                                messagecount: '4K',
+                                messageCount: '4K',
                             }}
                             discountData={discountData}
                             isCurrentSubscription={isCurrentPlan('Base')}
@@ -231,7 +231,7 @@ export const FreeComponent = ({ currentSubscription, discountData, userEmail,  a
                                 pageCount: 1000,
                                 tokenSize: '1M',
                                 projectCount: 10,
-                                messagecount: '10k',
+                                messageCount: '10k',
                             }}
                             discountData={discountData}
                             isCurrentSubscription={isCurrentPlan('Standard')}
@@ -244,7 +244,7 @@ export const FreeComponent = ({ currentSubscription, discountData, userEmail,  a
                                 pageCount: 2500,
                                 tokenSize: '2.5M',
                                 projectCount: 100,
-                                messagecount: '25K',
+                                messageCount: '25K',
                             }}
                             discountData={discountData}
                             isCurrentSubscription={isCurrentPlan('Premium')}
@@ -258,7 +258,7 @@ export const FreeComponent = ({ currentSubscription, discountData, userEmail,  a
                                 pageCount: 10000,
                                 tokenSize: 'Unlimited',
                                 projectCount: 'Unlimited',
-                                messagecount: '1M',
+                                messageCount: '1M',
                             }}
                             discountData={discountData}
                             isCurrentSubscription={isCurrentPlan('Enterprise')}

--- a/frontend/src/components/Pricing/FreeComponent.tsx
+++ b/frontend/src/components/Pricing/FreeComponent.tsx
@@ -218,7 +218,7 @@ export const FreeComponent = ({ currentSubscription, discountData, userEmail,  a
                                 pageCount: 100,
                                 tokenSize: '400K',
                                 projectCount: 5,
-                                messageCount: '4K',
+                                messageCount: '2K',
                             }}
                             discountData={discountData}
                             isCurrentSubscription={isCurrentPlan('Base')}
@@ -231,7 +231,7 @@ export const FreeComponent = ({ currentSubscription, discountData, userEmail,  a
                                 pageCount: 1000,
                                 tokenSize: '1M',
                                 projectCount: 10,
-                                messageCount: '10k',
+                                messageCount: '5k',
                             }}
                             discountData={discountData}
                             isCurrentSubscription={isCurrentPlan('Standard')}
@@ -244,7 +244,7 @@ export const FreeComponent = ({ currentSubscription, discountData, userEmail,  a
                                 pageCount: 2500,
                                 tokenSize: '2.5M',
                                 projectCount: 100,
-                                messageCount: '25K',
+                                messageCount: '10K',
                             }}
                             discountData={discountData}
                             isCurrentSubscription={isCurrentPlan('Premium')}
@@ -258,7 +258,7 @@ export const FreeComponent = ({ currentSubscription, discountData, userEmail,  a
                                 pageCount: 10000,
                                 tokenSize: 'Unlimited',
                                 projectCount: 'Unlimited',
-                                messageCount: '1M',
+                                messageCount: '40K',
                             }}
                             discountData={discountData}
                             isCurrentSubscription={isCurrentPlan('Enterprise')}

--- a/frontend/src/components/Pricing/FreeComponent.tsx
+++ b/frontend/src/components/Pricing/FreeComponent.tsx
@@ -49,8 +49,9 @@ export const FreeComponent = ({ currentSubscription, discountData, userEmail,  a
                 subscriptionData={{
                     type: 'AppSumo tier 1',
                     pageCount: 2000,
+                    messagecount: '1k',
                     tokenSize: '1M',
-                    projectCount: 20
+                    projectCount: 20,
                 }}
                 discountData={discountData}
                 isCurrentSubscription={isCurrentPlan('Base')}
@@ -63,8 +64,9 @@ export const FreeComponent = ({ currentSubscription, discountData, userEmail,  a
                 subscriptionData={{
                     type: 'AppSumo tier 2',
                     pageCount: 5000,
+                    messagecount: '2.5k',
                     tokenSize: '2.5M',
-                    projectCount: 50
+                    projectCount: 50,
                 }}
                 discountData={discountData}
                 isCurrentSubscription={isCurrentPlan('Base')}
@@ -77,8 +79,9 @@ export const FreeComponent = ({ currentSubscription, discountData, userEmail,  a
                 subscriptionData={{
                     type: 'AppSumo tier 3',
                     pageCount: 10000,
+                    messagecount: '5K',
                     tokenSize: '5M',
-                    projectCount: 'Unlimited'
+                    projectCount: 'Unlimited',
                 }}
                 discountData={discountData}
                 isCurrentSubscription={isCurrentPlan('Base')}
@@ -214,7 +217,8 @@ export const FreeComponent = ({ currentSubscription, discountData, userEmail,  a
                                 type: 'Base',
                                 pageCount: 100,
                                 tokenSize: '400K',
-                                projectCount: 5
+                                projectCount: 5,
+                                messagecount: '4K',
                             }}
                             discountData={discountData}
                             isCurrentSubscription={isCurrentPlan('Base')}
@@ -226,7 +230,8 @@ export const FreeComponent = ({ currentSubscription, discountData, userEmail,  a
                                 type: 'Standard',
                                 pageCount: 1000,
                                 tokenSize: '1M',
-                                projectCount: 10
+                                projectCount: 10,
+                                messagecount: '10k',
                             }}
                             discountData={discountData}
                             isCurrentSubscription={isCurrentPlan('Standard')}
@@ -238,7 +243,8 @@ export const FreeComponent = ({ currentSubscription, discountData, userEmail,  a
                                 type: 'Premium',
                                 pageCount: 2500,
                                 tokenSize: '2.5M',
-                                projectCount: 100
+                                projectCount: 100,
+                                messagecount: '25K',
                             }}
                             discountData={discountData}
                             isCurrentSubscription={isCurrentPlan('Premium')}
@@ -251,7 +257,8 @@ export const FreeComponent = ({ currentSubscription, discountData, userEmail,  a
                                 type: 'Enterprise',
                                 pageCount: 10000,
                                 tokenSize: 'Unlimited',
-                                projectCount: 'Unlimited'
+                                projectCount: 'Unlimited',
+                                messagecount: '1M',
                             }}
                             discountData={discountData}
                             isCurrentSubscription={isCurrentPlan('Enterprise')}

--- a/frontend/src/components/Pricing/PricingCard.tsx
+++ b/frontend/src/components/Pricing/PricingCard.tsx
@@ -28,8 +28,8 @@ const STANDARD_MONTHLY_PRICING = 49;
 const STANDARD_YEARLY_PRICING = 41;
 const PREMIUM_MONTHLY_PRICING = 99;
 const PREMIUM_YEARLY_PRICING = 82;
-const ENTERPRICE_MONTHLY_PRICING = 349;
-const ENTERPRICE_YEARLY_PRICING = 291;
+const ENTERPRISE_MONTHLY_PRICING = 349;
+const ENTERPRISE_YEARLY_PRICING = 291;
 
 const LIFETIME_PLAN1_PRICING = 59;
 const LIFETIME_PLAN2_PRICING = 118;
@@ -81,7 +81,7 @@ export const PricingCard = ({
                     basePrice = PREMIUM_YEARLY_PRICING;
                     break;
                 case 'Enterprise':
-                    basePrice = ENTERPRICE_YEARLY_PRICING;
+                    basePrice = ENTERPRISE_YEARLY_PRICING;
                     break;
             }
         } else {
@@ -96,7 +96,7 @@ export const PricingCard = ({
                     basePrice = PREMIUM_MONTHLY_PRICING;
                     break;
                 case 'Enterprise':
-                    basePrice = ENTERPRICE_MONTHLY_PRICING;
+                    basePrice = ENTERPRISE_MONTHLY_PRICING;
                     break;
             }
         }
@@ -185,7 +185,7 @@ export const PricingCard = ({
 				</ListItem>
                 <ListItem whiteSpace="nowrap">
                     <ListIcon boxSize={22} as={CheckCircleBlueIconMd} color={isPopular ? "white" : "blue.500"} />
-                    {subscriptionData.tokenSize} tokens / mo
+                    {subscriptionData.messagecount} message/mo
 				</ListItem>
                 <ListItem>
                     <ListIcon boxSize={22} as={CheckCircleBlueIconMd} color={isPopular ? "white" : "blue.500"} />

--- a/frontend/src/components/Pricing/PricingCard.tsx
+++ b/frontend/src/components/Pricing/PricingCard.tsx
@@ -185,7 +185,7 @@ export const PricingCard = ({
 				</ListItem>
                 <ListItem whiteSpace="nowrap">
                     <ListIcon boxSize={22} as={CheckCircleBlueIconMd} color={isPopular ? "white" : "blue.500"} />
-                    {subscriptionData.messagecount} message/mo
+                    {subscriptionData.messageCount} messages/mo
 				</ListItem>
                 <ListItem>
                     <ListIcon boxSize={22} as={CheckCircleBlueIconMd} color={isPopular ? "white" : "blue.500"} />

--- a/frontend/src/containers/App/App.tsx
+++ b/frontend/src/containers/App/App.tsx
@@ -57,24 +57,27 @@ export const App = (props: AppProps) => {
 		if(!userData) return null
 
 		try {	
-			let usage = (userData.monthUsage.count * 100 ) / userData?.subscriptionData?.maxTokens;
 
-			usage = usage.toFixed(2);
 
-			let isExceded = false;
+			let usage = (userData.monthUsage.msgCount * 100 ) / userData?.subscriptionData?.maxMessages;
 			
-			if(userData?.subscriptionData?.maxTokens !== undefined) {
-				isExceded = userData.monthUsage.count >= userData?.subscriptionData?.maxTokens
+			usage = parseFloat(usage.toFixed(2));
+
+			let isExceed = false;
+			
+			if(userData?.subscriptionData?.maxMessages !== undefined) {
+				isExceed = userData.monthUsage.msgCount >= userData?.subscriptionData?.maxMessages;
 			}
 
 
 			return <Box className={classNames(styles.usageCont, {
-				[styles.usageContExceeded]: isExceded,
+				[styles.usageContExceeded]: isExceed,
 			})}>
 				<Heading className={styles.usagePlan} size="h4" color="gray.500">{(userData?.subscriptionData?.name || '').toLowerCase().replace('app sumo', 'LTD')} plan</Heading>
-				<Box className={styles.usgaeNumbers}><Text as="span" fontWeight="bold">{formatNumber(userData.monthUsage.count)}</Text> / {formatNumber(userData?.subscriptionData?.maxTokens)}</Box>
+				<Box className={styles.usgaeNumbers}><Text as="span" fontWeight="bold">
+				{formatNumber(userData.monthUsage.msgCount)}</Text> / {formatNumber(userData?.subscriptionData?.maxMessages)}</Box>
 				<Text className={styles.usageLabel} fontSize="sm">Monthly usage limits</Text>
-				<Progress className={styles.progressbar} w="100%" value={usage} size='sm' colorScheme={isExceded ? 'red': 'blue'} borderRadius="md" />
+				<Progress className={styles.progressbar} w="100%" value={usage} size='sm' colorScheme={isExceed ? 'red': 'blue'} borderRadius="md" />
 				{
 					(userData?.subscriptionData?.type !== 'LIFETIME') ? (<Box w="100%" className={styles.usageUpgradeBtn}>
 					<Link to="/app/settings/subscription/">

--- a/frontend/src/containers/App/App.tsx
+++ b/frontend/src/containers/App/App.tsx
@@ -59,23 +59,23 @@ export const App = (props: AppProps) => {
 		try {	
 
 
-			let usage = (userData.monthUsage.msgCount * 100 ) / userData?.subscriptionData?.maxMessages;
+			let usage = (userData.monthUsage.weightedMsgCount * 100) / userData?.subscriptionData?.maxMessages;
 			
 			usage = parseFloat(usage.toFixed(2));
 
 			let isExceed = false;
 			
 			if(userData?.subscriptionData?.maxMessages !== undefined) {
-				isExceed = userData.monthUsage.msgCount >= userData?.subscriptionData?.maxMessages;
+				isExceed = userData.monthUsage.weightedMsgCount >= userData?.subscriptionData?.maxMessages;
 			}
 
 
 			return <Box className={classNames(styles.usageCont, {
 				[styles.usageContExceeded]: isExceed,
 			})}>
-				<Heading className={styles.usagePlan} size="h4" color="gray.500">{(userData?.subscriptionData?.name || '').toLowerCase().replace('app sumo', 'LTD')} plan</Heading>
+				<Heading className={styles.usagePlan} size="h4" color="gray.500">{(userData?.subscriptionData?.name || '').toLowerCase().replace('app sumo', 'LTD').replace(/\b\w/g, c => c.toUpperCase())} Plan</Heading>
 				<Box className={styles.usgaeNumbers}><Text as="span" fontWeight="bold">
-				{formatNumber(userData.monthUsage.msgCount)}</Text> / {formatNumber(userData?.subscriptionData?.maxMessages)}</Box>
+					{formatNumber(userData.monthUsage.weightedMsgCount)}</Text> / {formatNumber(userData?.subscriptionData?.maxMessages)}</Box>
 				<Text className={styles.usageLabel} fontSize="sm">Monthly usage limits</Text>
 				<Progress className={styles.progressbar} w="100%" value={usage} size='sm' colorScheme={isExceed ? 'red': 'blue'} borderRadius="md" />
 				{

--- a/frontend/src/containers/ChatBotsCustomize/ChatBotsCustomize.tsx
+++ b/frontend/src/containers/ChatBotsCustomize/ChatBotsCustomize.tsx
@@ -658,7 +658,8 @@ export const ChatBotsCustomize = ({
 																		<option value="gpt-4-0613">GPT-4</option>
 																		<option value="gpt-4-turbo-preview">GPT-4-Turbo</option>
 																	</Select>
-																	<FormHelperText fontSize="sm">Token consumption will be 30 times higher for GPT-4 compared to GPT-3.5.</FormHelperText>
+																	<FormHelperText fontSize="sm"> Note: Credits consumption vary with model.
+																		Credits per message: 1 credit for GPT-3.5-Turbo, 10 credits for GPT-4-Turbo, and 20 credits for GPT-4.</FormHelperText>
 																</FormControl>
 															)}
 														</Field>

--- a/frontend/src/services/appConfig.ts
+++ b/frontend/src/services/appConfig.ts
@@ -23,6 +23,7 @@ export interface UserMonthlyUsage {
   count: number
   msgCount: number
   rawTokenCount: number
+  weightedMsgCount: number; // Message count multiplied by model factor
 }
 
 export const CurrentUser: any = {

--- a/frontend/src/services/appConfig.ts
+++ b/frontend/src/services/appConfig.ts
@@ -11,10 +11,18 @@ export interface User {
         maxChatbots :number
         maxChunksPerPage :number
         maxPages :number
-        maxTokens :number
+        maxMessages:number
         name : SubscriptionType
         type: "MONTHLY" | "YEARLY" | "LIFETIME"
-    }
+    },
+    monthUsage: UserMonthlyUsage,
+}
+
+export interface UserMonthlyUsage {
+  month: string
+  count: number
+  msgCount: number
+  rawTokenCount: number
 }
 
 export const CurrentUser: any = {

--- a/frontend/src/types/subscription.type.ts
+++ b/frontend/src/types/subscription.type.ts
@@ -1,10 +1,13 @@
 export type SubscriptionType =
+    | 'FREE'
     | 'Base'
     | 'Standard'
     | 'Premium'
-    | 'Enterprise';
+    | 'Enterprise'
+    | 'DEMO'
+    | 'Self Hosted';
 
-    export type SubscriptionTypeLTD =
+export type SubscriptionTypeLTD =
     | 'AppSumo tier 1'
     | 'AppSumo tier 2'
     | 'AppSumo tier 3'
@@ -45,7 +48,7 @@ export interface SubscriptionData {
     pageCount: PageCount;
     tokenSize: TokenSize;
     projectCount: ProjectCount;
-    messagecount: messageCount;
+    messageCount: messageCount;
 
 }
 
@@ -54,7 +57,7 @@ export interface SubscriptionDataLTD {
     pageCount: PageCountLTD;
     tokenSize: TokenSizeLTD;
     projectCount: ProjectCountLTD;
-    messagecount: messageCountLTD;
+    messageCount: messageCountLTD;
 }
 
 export interface DiscoutData {

--- a/frontend/src/types/subscription.type.ts
+++ b/frontend/src/types/subscription.type.ts
@@ -28,6 +28,8 @@ export type PageCount = 100 | 1000 | 2500 | 10000;
 
 export type TokenSize = "400K" | "1M" | "2.5M" | "Unlimited";
 
+export type messageCount = "4K" | "10k" | "25K" | "1M";
+
 export type ProjectCount = 5 | 10 | 100 | "Unlimited";
 
 export type PageCountLTD = 2000 | 5000 | 10000;
@@ -36,11 +38,15 @@ export type TokenSizeLTD = "1M" | "2.5M" | "5M";
 
 export type ProjectCountLTD = 20 | 50 | "Unlimited";
 
+export type messageCountLTD = "1k" | "2.5k" | "5K";
+
 export interface SubscriptionData {
     type: SubscriptionType;
     pageCount: PageCount;
     tokenSize: TokenSize;
     projectCount: ProjectCount;
+    messagecount: messageCount;
+
 }
 
 export interface SubscriptionDataLTD {
@@ -48,6 +54,7 @@ export interface SubscriptionDataLTD {
     pageCount: PageCountLTD;
     tokenSize: TokenSizeLTD;
     projectCount: ProjectCountLTD;
+    messagecount: messageCountLTD;
 }
 
 export interface DiscoutData {

--- a/frontend/src/types/subscription.type.ts
+++ b/frontend/src/types/subscription.type.ts
@@ -31,7 +31,7 @@ export type PageCount = 100 | 1000 | 2500 | 10000;
 
 export type TokenSize = "400K" | "1M" | "2.5M" | "Unlimited";
 
-export type messageCount = "4K" | "10k" | "25K" | "1M";
+export type messageCount = "2K" | "5k" | "10K" | "40K";
 
 export type ProjectCount = 5 | 10 | 100 | "Unlimited";
 

--- a/src/knowledgebase/chatbot/chatbot.service.ts
+++ b/src/knowledgebase/chatbot/chatbot.service.ts
@@ -155,9 +155,9 @@ export class ChatbotService {
   calculateMsgCountBasedOnModel(messageCount: number, model: string) {
     switch (model) {
       case 'gpt-4-0613': // GPT-4
-        return messageCount * 60;
-      case 'gpt-4-turbo-preview': // GPT-4-Turbo
         return messageCount * 20;
+      case 'gpt-4-turbo-preview': // GPT-4-Turbo
+        return messageCount * 10;
       case 'gpt-3.5-turbo': // GPT-3.5-Turbo
       default:
         return messageCount;

--- a/src/knowledgebase/chatbot/chatbot.service.ts
+++ b/src/knowledgebase/chatbot/chatbot.service.ts
@@ -66,7 +66,7 @@ export class ChatbotService {
     @Inject(REDIS) private redis: Redis,
     @Inject(forwardRef(() => WebSocketChatGateway))
     private webSocketChatGateway: WebSocketChatGateway,
-  ) {}
+  ) { }
 
   private async putChatSessionDataToCache(sessionData: ChatSession) {
     return this.redis.set(
@@ -194,19 +194,22 @@ export class ChatbotService {
     );
 
     // We are sure that this function will be invoked only if the token
-    // limit is exeeded for the current month, so no need of verifying
+    // limit is exceeded for the current month, so no need of verifying
     // if the monthUsage.month is current month
 
-    const maxTokens = subscriptionPlan.maxTokens;
+    const maxMessages = subscriptionPlan.maxMessages;
 
     let emailSendFn: (email: string) => Promise<any>;
     let emailSendTaskName;
 
-    if (monthUsageData.monthUsage.count >= maxTokens) {
-      emailSendTaskName = `EMAIL_TOKEN_100_${userId}_${monthUsageData.monthUsage.month}`;
+    if (monthUsageData.monthUsage.weightedMsgCount >= maxMessages) {
+      emailSendTaskName = `EMAIL_MSG_100_${userId}_${monthUsageData.monthUsage.month}`;
       emailSendFn = this.emailService.sendToken100ExhaustedEmail;
-    } else if (monthUsageData.monthUsage.count >= 0.8 * maxTokens) {
-      emailSendTaskName = `EMAIL_TOKEN_80_${userId}_${monthUsageData.monthUsage.month}`;
+    } else if (
+      monthUsageData.monthUsage.weightedMsgCount >=
+      0.8 * maxMessages
+    ) {
+      emailSendTaskName = `EMAIL_MSG_80_${userId}_${monthUsageData.monthUsage.month}`;
       emailSendFn = this.emailService.sendToken80ExhaustedEmail;
     }
 
@@ -236,6 +239,13 @@ export class ChatbotService {
     });
   }
 
+  /**
+   * Checks if the user is under the usage limits.
+   * @param userId - The ID of the user.
+   * @param maxUsage - The maximum message count allowed per month.
+   * @param customKeys - Optional custom key data.
+   * @returns A Promise that resolves to a boolean indicating whether the user is under the usage limits.
+   */
   private async isUseUnderUsageLimits(
     userId: ObjectId,
     maxUsage: number,
@@ -264,13 +274,13 @@ export class ChatbotService {
       // If the last monthusage was reported for current month and year
       // check the usage count
       if (year === currYear && month === currMonth) {
-        if (monthUsageData.monthUsage.count >= 0.8 * maxUsage) {
+        if (monthUsageData.monthUsage.weightedMsgCount >= 0.8 * maxUsage) {
           // Trigger notification to user about token limit
           const client = this.celeryClient.get(CeleryClientQueue.CRAWLER);
           const task = client.createTask('tasks.notify_token_limit');
           await task.applyAsync([userId.toHexString()]);
         }
-        return monthUsageData.monthUsage.count < maxUsage;
+        return monthUsageData.monthUsage.weightedMsgCount < maxUsage;
       } else {
         // Else return true as this is the first call for current month
         return true;
@@ -294,10 +304,28 @@ export class ChatbotService {
       throw new HttpException('Invalid Session Id', HttpStatus.NOT_FOUND);
     }
 
+    // The maxMessages field is introduced newly and will not be available for old sessions. So,
+    // if the maxMessages field is not available, then we will fetch the subscription plan for the user
+    // and get the maxMessages from there. Then save it to the sessionData for future use.
+    let maxMessages = sessionData.subscriptionData.maxMessages;
+
+    if (!maxMessages) {
+      const user = await this.userService.findUserById(
+        sessionData.userId.toString(),
+      );
+      const subscriptionPlan = this.subPlanInfoService.getSubscriptionPlanInfo(
+        user.activeSubscription,
+      );
+
+      maxMessages = subscriptionPlan.maxMessages;
+      // update the sessionData with the maxMessages
+      sessionData.subscriptionData.maxMessages = maxMessages;
+    }
+
     // Check usage limits for user
     const allowUsage = await this.isUseUnderUsageLimits(
       sessionData.userId,
-      sessionData.subscriptionData.maxTokens,
+      sessionData.subscriptionData.maxMessages,
       sessionData.customKeys,
     );
     if (!allowUsage) {
@@ -421,10 +449,28 @@ export class ChatbotService {
       throw new HttpException('Invalid Session Id', HttpStatus.NOT_FOUND);
     }
 
+    // The maxMessages field is introduced newly and will not be available for old sessions. So,
+    // if the maxMessages field is not available, then we will fetch the subscription plan for the user
+    // and get the maxMessages from there. Then save it to the sessionData for future use.
+    let maxMessages = sessionData.subscriptionData.maxMessages;
+
+    if (!maxMessages) {
+      const user = await this.userService.findUserById(
+        sessionData.userId.toString(),
+      );
+      const subscriptionPlan = this.subPlanInfoService.getSubscriptionPlanInfo(
+        user.activeSubscription,
+      );
+
+      maxMessages = subscriptionPlan.maxMessages;
+      // update the sessionData with the maxMessages
+      sessionData.subscriptionData.maxMessages = maxMessages;
+    }
+
     // Check usage limits for user
     const allowUsage = await this.isUseUnderUsageLimits(
       sessionData.userId,
-      sessionData.subscriptionData.maxTokens,
+      sessionData.subscriptionData.maxMessages,
       sessionData.customKeys,
     );
     const kbId = sessionData.knowledgebaseId;
@@ -737,11 +783,11 @@ export class ChatbotService {
       data.query,
       data.context.map(
         (c) =>
-          ({
-            content: c,
-            score: 0.9,
-            url: 'http://test',
-          } as any),
+        ({
+          content: c,
+          score: 0.9,
+          url: 'http://test',
+        } as any),
       ),
       data.prevMessages as any,
       data.defaultAnswer,

--- a/src/knowledgebase/chatbot/chatbot.service.ts
+++ b/src/knowledgebase/chatbot/chatbot.service.ts
@@ -121,6 +121,12 @@ export class ChatbotService {
       session.model,
     );
 
+    const messageCount = totalTokens > 0 ? 1 : 0;
+    const weightedMsgCount =
+      messageCount > 0
+        ? this.calculateMsgCountBasedOnModel(messageCount, session.model)
+        : 0;
+
     return Promise.all([
       this.setChatSessionData(session),
       this.kbDbService.addMsgToChatSession(session._id, msg),
@@ -128,13 +134,33 @@ export class ChatbotService {
         session.userId,
         totalTokens,
         msg.qTokens + msg.aTokens,
+        weightedMsgCount,
       ),
       this.kbDbService.updateMonthlyUsageByN(
         session.knowledgebaseId,
         totalTokens,
         msg.qTokens + msg.aTokens,
+        weightedMsgCount,
       ),
     ]);
+  }
+
+  // TODO: Recheck the logic for calculating the message count based on the model
+  /**
+   * Calculates the message count based on the specified model.
+   * @param messageCount The number of messages.
+   * @param model The model to calculate the message count for.
+   * @returns The calculated message count.
+   */
+  calculateMsgCountBasedOnModel(messageCount: number, model: string) {
+    switch (model) {
+      case 'gpt-4-0613': // GPT-4
+        return messageCount * 60;
+      case 'gpt-4-turbo-preview': // GPT-4-Turbo
+        return messageCount * 20;
+      default:
+        return messageCount;
+    }
   }
 
   private async updateSessionDataWithNewManualMsg(

--- a/src/knowledgebase/chatbot/chatbot.service.ts
+++ b/src/knowledgebase/chatbot/chatbot.service.ts
@@ -675,7 +675,7 @@ export class ChatbotService {
       slackThreadId: slackThreadId,
       kbName: `${kb.name} assistant`,
       defaultAnswer: kb.defaultAnswer,
-      model: kb.model,
+      model: kb.model || 'gpt-3.5-turbo',
       prompt,
       isDemo: kb.isDemo,
       isManual: false,

--- a/src/knowledgebase/chatbot/chatbot.service.ts
+++ b/src/knowledgebase/chatbot/chatbot.service.ts
@@ -158,6 +158,7 @@ export class ChatbotService {
         return messageCount * 60;
       case 'gpt-4-turbo-preview': // GPT-4-Turbo
         return messageCount * 20;
+      case 'gpt-3.5-turbo': // GPT-3.5-Turbo
       default:
         return messageCount;
     }
@@ -1023,6 +1024,7 @@ export class ChatbotService {
         return qTokens * 60 + aTokens * 40;
       case 'gpt-4-turbo-preview': // GPT-4-Turbo
         return qTokens * 20 + aTokens * 20;
+      case 'gpt-3.5-turbo': // GPT-3.5
       default:
         return qTokens + aTokens;
     }

--- a/src/knowledgebase/knowledgebase-db.service.ts
+++ b/src/knowledgebase/knowledgebase-db.service.ts
@@ -222,6 +222,7 @@ export class KnowledgebaseDbService {
     kbId: ObjectId,
     n: number,
     rawTokenCount: number,
+    weightedMsgCount: number,
   ) {
     const messgCount = n > 0 ? 1 : 0;
     await this.knowledgebaseCollection.updateOne({ _id: kbId }, [
@@ -262,6 +263,17 @@ export class KnowledgebaseDbService {
                     rawTokenCount,
                   ],
                 },
+                weightedMsgCount: {
+                  $add: [
+                    {
+                      $ifNull: [
+                        '$monthUsage.weightedMsgCount',
+                        '$monthUsage.msgCount',
+                      ],
+                    },
+                    weightedMsgCount,
+                  ],
+                },
               },
               else: {
                 month: {
@@ -278,6 +290,7 @@ export class KnowledgebaseDbService {
                 count: n,
                 msgCount: messgCount,
                 rawTokenCount: rawTokenCount,
+                weightedMsgCount: weightedMsgCount,
               },
             },
           },

--- a/src/knowledgebase/knowledgebase.service.ts
+++ b/src/knowledgebase/knowledgebase.service.ts
@@ -175,6 +175,7 @@ export class KnowledgebaseService {
       createdAt: ts,
       updatedAt: ts,
       embeddingModel: EmbeddingModel.OPENAI_EMBEDDING_3,
+      model: 'gpt-3.5-turbo',
     };
     const kbData = await this.kbDbService.insertKnowledgebase(kb);
 

--- a/src/subscription/subscription.const.ts
+++ b/src/subscription/subscription.const.ts
@@ -34,7 +34,7 @@ export const subscriptionPlanData: Record<Subscription, SubscriptionPlanInfo> =
       maxTokens: 4000000,
       maxPages: 100,
       maxChunksPerPage: 100,
-      maxMessages: 4000,
+      maxMessages: 2000,
     },
     [Subscription.STANDARD_MONTHLY]: {
       name: 'Standard',
@@ -43,7 +43,7 @@ export const subscriptionPlanData: Record<Subscription, SubscriptionPlanInfo> =
       maxTokens: 10000000,
       maxPages: 1000,
       maxChunksPerPage: 100,
-      maxMessages: 10000,
+      maxMessages: 5000,
     },
     [Subscription.PREMIUM_MONTHLY]: {
       name: 'Premium',
@@ -52,7 +52,7 @@ export const subscriptionPlanData: Record<Subscription, SubscriptionPlanInfo> =
       maxTokens: 25000000,
       maxPages: 2500,
       maxChunksPerPage: 100,
-      maxMessages: 25000,
+      maxMessages: 10000,
     },
     [Subscription.ENTERPRISE_MONTHLY]: {
       name: 'Enterprise',
@@ -61,7 +61,7 @@ export const subscriptionPlanData: Record<Subscription, SubscriptionPlanInfo> =
       maxTokens: 95000000,
       maxPages: 10000,
       maxChunksPerPage: 100,
-      maxMessages: 100000,
+      maxMessages: 40000,
     },
     [Subscription.BASE_YEARLY]: {
       name: 'Base',
@@ -70,7 +70,7 @@ export const subscriptionPlanData: Record<Subscription, SubscriptionPlanInfo> =
       maxTokens: 4000000,
       maxPages: 100,
       maxChunksPerPage: 100,
-      maxMessages: 4000,
+      maxMessages: 2000,
     },
     [Subscription.STANDARD_YEARLY]: {
       name: 'Standard',
@@ -79,7 +79,7 @@ export const subscriptionPlanData: Record<Subscription, SubscriptionPlanInfo> =
       maxTokens: 10000000,
       maxPages: 1000,
       maxChunksPerPage: 100,
-      maxMessages: 10000,
+      maxMessages: 5000,
     },
     [Subscription.PREMIUM_YEARLY]: {
       name: 'Premium',
@@ -88,7 +88,7 @@ export const subscriptionPlanData: Record<Subscription, SubscriptionPlanInfo> =
       maxTokens: 25000000,
       maxPages: 2500,
       maxChunksPerPage: 100,
-      maxMessages: 25000,
+      maxMessages: 10000,
     },
     [Subscription.ENTERPRISE_YEARLY]: {
       name: 'Enterprise',
@@ -97,7 +97,7 @@ export const subscriptionPlanData: Record<Subscription, SubscriptionPlanInfo> =
       maxTokens: 95000000,
       maxPages: 10000,
       maxChunksPerPage: 100,
-      maxMessages: 100000,
+      maxMessages: 40000,
     },
     [Subscription.DEMO_ACCOUNT]: {
       name: 'DEMO',

--- a/src/subscription/subscription.const.ts
+++ b/src/subscription/subscription.const.ts
@@ -13,6 +13,7 @@ export interface SubscriptionPlanInfo {
   maxTokens: number;
   maxPages: number;
   maxChunksPerPage: number;
+  maxMessages: number;
 }
 
 export const subscriptionPlanData: Record<Subscription, SubscriptionPlanInfo> =
@@ -24,6 +25,7 @@ export const subscriptionPlanData: Record<Subscription, SubscriptionPlanInfo> =
       maxTokens: 20000,
       maxPages: 25,
       maxChunksPerPage: 50,
+      maxMessages: 1000,
     },
     [Subscription.BASE_MONTHLY]: {
       name: 'Base',
@@ -32,6 +34,7 @@ export const subscriptionPlanData: Record<Subscription, SubscriptionPlanInfo> =
       maxTokens: 4000000,
       maxPages: 100,
       maxChunksPerPage: 100,
+      maxMessages: 5000,
     },
     [Subscription.STANDARD_MONTHLY]: {
       name: 'Standard',
@@ -40,6 +43,7 @@ export const subscriptionPlanData: Record<Subscription, SubscriptionPlanInfo> =
       maxTokens: 10000000,
       maxPages: 1000,
       maxChunksPerPage: 100,
+      maxMessages: 10000,
     },
     [Subscription.PREMIUM_MONTHLY]: {
       name: 'Premium',
@@ -48,6 +52,7 @@ export const subscriptionPlanData: Record<Subscription, SubscriptionPlanInfo> =
       maxTokens: 25000000,
       maxPages: 2500,
       maxChunksPerPage: 100,
+      maxMessages: 50000,
     },
     [Subscription.ENTERPRISE_MONTHLY]: {
       name: 'Enterprise',
@@ -56,6 +61,7 @@ export const subscriptionPlanData: Record<Subscription, SubscriptionPlanInfo> =
       maxTokens: 95000000,
       maxPages: 10000,
       maxChunksPerPage: 100,
+      maxMessages: 100000,
     },
     [Subscription.BASE_YEARLY]: {
       name: 'Base',
@@ -64,6 +70,7 @@ export const subscriptionPlanData: Record<Subscription, SubscriptionPlanInfo> =
       maxTokens: 4000000,
       maxPages: 100,
       maxChunksPerPage: 100,
+      maxMessages: 5000,
     },
     [Subscription.STANDARD_YEARLY]: {
       name: 'Standard',
@@ -72,6 +79,7 @@ export const subscriptionPlanData: Record<Subscription, SubscriptionPlanInfo> =
       maxTokens: 10000000,
       maxPages: 1000,
       maxChunksPerPage: 100,
+      maxMessages: 10000,
     },
     [Subscription.PREMIUM_YEARLY]: {
       name: 'Premium',
@@ -80,6 +88,7 @@ export const subscriptionPlanData: Record<Subscription, SubscriptionPlanInfo> =
       maxTokens: 25000000,
       maxPages: 2500,
       maxChunksPerPage: 100,
+      maxMessages: 50000,
     },
     [Subscription.ENTERPRISE_YEARLY]: {
       name: 'Enterprise',
@@ -88,6 +97,7 @@ export const subscriptionPlanData: Record<Subscription, SubscriptionPlanInfo> =
       maxTokens: 95000000,
       maxPages: 10000,
       maxChunksPerPage: 100,
+      maxMessages: 100000,
     },
     [Subscription.DEMO_ACCOUNT]: {
       name: 'DEMO',
@@ -96,6 +106,7 @@ export const subscriptionPlanData: Record<Subscription, SubscriptionPlanInfo> =
       maxTokens: 995000000,
       maxPages: 200,
       maxChunksPerPage: 100,
+      maxMessages: 99900000,
     },
     // APP SUMO PLANS
     [Subscription.APPSUMO_TIER1]: {
@@ -105,6 +116,7 @@ export const subscriptionPlanData: Record<Subscription, SubscriptionPlanInfo> =
       maxTokens: 1000000,
       maxPages: 2000,
       maxChunksPerPage: 100,
+      maxMessages: 10000,
     },
     [Subscription.APPSUMO_TIER2]: {
       name: 'App Sumo Tier 2',
@@ -113,6 +125,7 @@ export const subscriptionPlanData: Record<Subscription, SubscriptionPlanInfo> =
       maxTokens: 2500000,
       maxPages: 5000,
       maxChunksPerPage: 100,
+      maxMessages: 50000,
     },
     [Subscription.APPSUMO_TIER3]: {
       name: 'App Sumo Tier 3',
@@ -121,6 +134,7 @@ export const subscriptionPlanData: Record<Subscription, SubscriptionPlanInfo> =
       maxTokens: 5000000,
       maxPages: 10000,
       maxChunksPerPage: 100,
+      maxMessages: 100000,
     },
     [Subscription.SELF_HOSTED]: {
       name: 'Self Hosted',
@@ -129,5 +143,6 @@ export const subscriptionPlanData: Record<Subscription, SubscriptionPlanInfo> =
       maxTokens: 5000000,
       maxPages: 100000,
       maxChunksPerPage: 500,
+      maxMessages: 1000000,
     },
   };

--- a/src/subscription/subscription.const.ts
+++ b/src/subscription/subscription.const.ts
@@ -25,7 +25,7 @@ export const subscriptionPlanData: Record<Subscription, SubscriptionPlanInfo> =
       maxTokens: 20000,
       maxPages: 25,
       maxChunksPerPage: 50,
-      maxMessages: 1000,
+      maxMessages: 20,
     },
     [Subscription.BASE_MONTHLY]: {
       name: 'Base',
@@ -34,7 +34,7 @@ export const subscriptionPlanData: Record<Subscription, SubscriptionPlanInfo> =
       maxTokens: 4000000,
       maxPages: 100,
       maxChunksPerPage: 100,
-      maxMessages: 5000,
+      maxMessages: 4000,
     },
     [Subscription.STANDARD_MONTHLY]: {
       name: 'Standard',
@@ -52,7 +52,7 @@ export const subscriptionPlanData: Record<Subscription, SubscriptionPlanInfo> =
       maxTokens: 25000000,
       maxPages: 2500,
       maxChunksPerPage: 100,
-      maxMessages: 50000,
+      maxMessages: 25000,
     },
     [Subscription.ENTERPRISE_MONTHLY]: {
       name: 'Enterprise',
@@ -70,7 +70,7 @@ export const subscriptionPlanData: Record<Subscription, SubscriptionPlanInfo> =
       maxTokens: 4000000,
       maxPages: 100,
       maxChunksPerPage: 100,
-      maxMessages: 5000,
+      maxMessages: 4000,
     },
     [Subscription.STANDARD_YEARLY]: {
       name: 'Standard',
@@ -88,7 +88,7 @@ export const subscriptionPlanData: Record<Subscription, SubscriptionPlanInfo> =
       maxTokens: 25000000,
       maxPages: 2500,
       maxChunksPerPage: 100,
-      maxMessages: 50000,
+      maxMessages: 25000,
     },
     [Subscription.ENTERPRISE_YEARLY]: {
       name: 'Enterprise',
@@ -116,7 +116,7 @@ export const subscriptionPlanData: Record<Subscription, SubscriptionPlanInfo> =
       maxTokens: 1000000,
       maxPages: 2000,
       maxChunksPerPage: 100,
-      maxMessages: 10000,
+      maxMessages: 1000,
     },
     [Subscription.APPSUMO_TIER2]: {
       name: 'App Sumo Tier 2',
@@ -125,7 +125,7 @@ export const subscriptionPlanData: Record<Subscription, SubscriptionPlanInfo> =
       maxTokens: 2500000,
       maxPages: 5000,
       maxChunksPerPage: 100,
-      maxMessages: 50000,
+      maxMessages: 2500,
     },
     [Subscription.APPSUMO_TIER3]: {
       name: 'App Sumo Tier 3',
@@ -134,7 +134,7 @@ export const subscriptionPlanData: Record<Subscription, SubscriptionPlanInfo> =
       maxTokens: 5000000,
       maxPages: 10000,
       maxChunksPerPage: 100,
-      maxMessages: 100000,
+      maxMessages: 5000,
     },
     [Subscription.SELF_HOSTED]: {
       name: 'Self Hosted',

--- a/src/user/user.schema.ts
+++ b/src/user/user.schema.ts
@@ -29,6 +29,7 @@ export interface UserMonthlyUsage {
   count: number; // Total token count (considering model used)
   msgCount: number;
   rawTokenCount: number; // Token count (not considering model used)
+  weightedMsgCount: number; // Message count multiplied by model factor
 }
 
 export interface SubscriptionData {

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -231,6 +231,10 @@ export class UserService {
       };
     }
 
+    if (userData.monthUsage && !userData.monthUsage.msgCount) {
+      userData.monthUsage.msgCount = 0;
+    }
+
     // Since weightedMsgCount was newly added, set it to msgCount if not present
     if (userData.monthUsage && !userData.monthUsage.weightedMsgCount) {
       userData.monthUsage.weightedMsgCount = userData.monthUsage.msgCount;

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -231,6 +231,11 @@ export class UserService {
       };
     }
 
+    // Since weightedMsgCount was newly added, set it to msgCount if not present
+    if (userData.monthUsage && !userData.monthUsage.weightedMsgCount) {
+      userData.monthUsage.weightedMsgCount = userData.monthUsage.msgCount;
+    }
+
     const subscriptionData = this.subsPlanService.getSubscriptionPlanInfo(
       user.activeSubscription,
     );


### PR DESCRIPTION
- Store msgCount and weightedMsgCount(msgCount multiplied by weight of model Used) for each user and knowledgebase.
- Added maxMessages for each Subscription plan.
- Limit usage based on the maxMessages allowed in the plan.
- Set GPT-3.5-turbo as the default model while creating knowledgebase.
- Show weightedMsgCount in the usage graph in the UI.