### PR TITLE
Limit max-old-space-size to avoid allocation failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ COPY --chown=node:node . .
 
 # Set NODE_ENV environment variable
 ENV NODE_ENV production
+# If you get `Allocation failed`, lower this https://nodejs.org/api/cli.html#cli_max_old_space_size_size_in_megabytes
+ENV NODE_OPTIONS --max-old-space-size=8192
 
 # Run the build command which creates the production bundle
 RUN yarn run build

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -16,6 +16,9 @@ RUN npm install
 COPY . .
 COPY .env.docker .env
 
+# If you get `Allocation failed`, lower this https://nodejs.org/api/cli.html#cli_max_old_space_size_size_in_megabytes
+ENV NODE_OPTIONS --max-old-space-size=8192
+
 # Building our application
 RUN npm run build
 

--- a/widget/Dockerfile
+++ b/widget/Dockerfile
@@ -15,6 +15,9 @@ RUN npm install
 # Copying all the files in our project
 COPY . .
 
+# If you get `Allocation failed`, lower this https://nodejs.org/api/cli.html#cli_max_old_space_size_size_in_megabytes
+ENV NODE_OPTIONS --max-old-space-size=8192
+
 # Building our application
 RUN npm run build
 


### PR DESCRIPTION
I had to limit the max-old-space-size to build.
I was getting this error.
```
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
```

It can probably make do with a lower value, I did not try.