### PR TITLE
Make Pirsch analytics integration optional

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,10 @@ services:
       - web
 
   widget:
-    build: ./widget
+    build:
+      context: ./widget
+      args:
+         - PIRSCH_KEY
     ports:
       - "3031:80"
     depends_on:

--- a/widget/Dockerfile
+++ b/widget/Dockerfile
@@ -15,6 +15,8 @@ RUN npm install
 # Copying all the files in our project
 COPY . .
 
+ARG PIRSCH_KEY
+
 # Building our application
 RUN npm run build
 

--- a/widget/index.html
+++ b/widget/index.html
@@ -1365,8 +1365,16 @@
         }
 
     </script>
-    <script defer type="text/javascript" src="https://api.pirsch.io/pirsch.js" id="pirschjs"
-        data-code="VEW6587Xat8LXjE7ejokwXUked6s7udc"></script>
+    <script type="module">
+        const pirsch_key = process.env.PIRSCH_KEY
+        if (pirsch_key) {
+            let script = document.createElement("script");
+            script.setAttribute("src", "https://api.pirsch.io/pirsch.js");
+            script.setAttribute("id", "pirschjs");
+            script.setAttribute("defer", "");
+            script.setAttribute("data-code", pirsch_key);
+        }
+    </script>
 </body>
 
 


### PR DESCRIPTION
In order to build with a Pirsch key:
`docker compose build --build-arg PIRSCH_KEY="VEW6587Xat8LXjE7ejokwXUked6s7udc"`

Parcel processes `process.env.PIRSCH_KEY` as a macro, so it will evaluate it at build time.

When supplying the `PIRSCH_KEY`, it generates the following `index.html`:
```
    <script>!function(){let t="VEW6587Xat8LXjE7ejokwXUked6s7udc";if(t){let e=document.createElement("script");e.setAttribute("src","https://api.pirsch.io/pirsch.js"),e.setAttribute("id","pirschjs"),e.setAttribute("defer",""),e.setAttribute("data-code",t)}}();</script><script>!function(){let t="VEW6587Xat8LXjE7ejokwXUked6s7udc";if(t){let e=document.createElement("script");e.setAttribute("src","https://api.pirsch.io/pirsch.js"),e.setAttribute("id","pirschjs"),e.setAttribute("defer",""),e.setAttribute("data-code",t)}}();</script>
```

Without supplying the `PIRSCH_KEY`, it generates:
```
    <script>!function(){let t=void 0;if(t){let e=document.createElement("script");e.setAttribute("src","https://api.pirsch.io/pirsch.js"),e.setAttribute("id","pirschjs"),e.setAttribute("defer",""),e.setAttribute("data-code",t)}}();</script>
```

Closes: https://github.com/webwhiz-ai/webwhiz/issues/220