### PR TITLE
Set widget BASE_TARGET on ENV variables

### DIFF
--- a/widget/.env.development
+++ b/widget/.env.development
@@ -1,1 +1,0 @@
-BASE_TARGET="_parent"

--- a/widget/.env.development
+++ b/widget/.env.development
@@ -1,0 +1,1 @@
+BASE_TARGET="_parent"

--- a/widget/Dockerfile
+++ b/widget/Dockerfile
@@ -3,6 +3,7 @@ FROM node:14-alpine AS builder_widget
 
 # Declaring env
 ENV NODE_ENV production
+ARG BASE_TARGET _parent
 
 # Setting up the work directory
 WORKDIR /app

--- a/widget/index.html
+++ b/widget/index.html
@@ -237,10 +237,8 @@
 
         // Open links in a new tab
         const baseTag = document.querySelector('head base');
-        const baseTarget = process.env.BASE_TARGET;
-        if (baseTarget) {
-            baseTag.setAttribute('target', baseTarget);
-        }
+        const baseTarget = process.env.BASE_TARGET || "_parent";
+        baseTag.setAttribute('target', baseTarget);
 
         /**
          * Iframe communications

--- a/widget/index.html
+++ b/widget/index.html
@@ -187,11 +187,8 @@
         integrity="sha384-mZLF4UVrpi/QTWPA7BjNPEnkIfRFn4ZEO3Qt/HFklTJBj/gBOV8G3HcKn4NfQblz"
         crossorigin="anonymous"></script>
 
-
-
-    <script>
+    <script type="module">
         const STREAM_RESPONSE = true;
-
 
         // message format
 
@@ -236,6 +233,13 @@
         }
         if (urlParams.get('hide-chat-actions') === 'true') {
             chatWidget.classList.add('hide-chat-actions');
+        }
+
+        // Open links in a new tab
+        const baseTag = document.querySelector('head base');
+        const baseTarget = process.env.BASE_TARGET;
+        if (baseTarget) {
+            baseTag.setAttribute('target', baseTarget);
         }
 
         /**
@@ -1368,6 +1372,5 @@
     <script defer type="text/javascript" src="https://api.pirsch.io/pirsch.js" id="pirschjs"
         data-code="VEW6587Xat8LXjE7ejokwXUked6s7udc"></script>
 </body>
-
 
 </html>


### PR DESCRIPTION
It should be possible to decide where the widget's links should be open. 

The PR makes it possible to set an ENV variable at build time to open the links in a new tab by setting BASE_TARGET to _blank.