### PR TITLE
Widget nginx: More Content-Security-Policy header

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,10 @@ The following variables as mandatory
 
 Set the value for the following variables - `MONGO_URI`, `MONGO_DBNAME`, `REDIS_HOST`, `REDIS_PORT`
 
+3. Configure `widget/nginx-variables.conf`.
+
+`set $FRAME_ANCESTORS "http:"`, to allow unencrypted iframing of the widget in your development environment.
+
 ## Installing dependencies and running app
 
 From the root folder run the following commands

--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ docker-compose down
 sudo docker-compose up --build --force-recreate
 ```
 
+3. Configure `widget/nginx-variables.conf`.
+
+`set $FRAME_ANCESTORS "https://your.domain"`, to allow iframing of the widget on `your.domain`.
+
 ### 🛃 Manual
 
 WebWhiz is designed to be used as a production grade Chatbot that can be scaled up or down to handle any volume of data.
@@ -152,6 +156,10 @@ The following variables as mandatory
 2. Inside the workers folder create a copy of the `.env.sample` and rename as `.env`.
 
 Set the value for the following variables - `MONGO_URI`, `MONGO_DBNAME`, `REDIS_HOST`, `REDIS_PORT`
+
+3. Configure `widget/nginx-variables.conf`.
+
+`set $FRAME_ANCESTORS "https://your.domain"`, to allow iframing of the widget on `your.domain`.
 
 #### Installing dependencies and running app
 

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -5,6 +5,8 @@ upstream web {
 server {
   listen 80;
 
+  add_header Content-Security-Policy "frame-ancestors 'none'" always;
+
   location ~ ^/api(/?)(.*) {
     proxy_pass http://web/$2$is_args$args;
   }

--- a/widget/Dockerfile
+++ b/widget/Dockerfile
@@ -26,6 +26,7 @@ COPY --from=builder_widget /app/dist /usr/share/nginx/html
 
 # Copying our nginx.conf
 COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY nginx-variables.conf /etc/nginx/nginx-variables.conf
 
 # Expose port
 EXPOSE 80

--- a/widget/index.html
+++ b/widget/index.html
@@ -181,7 +181,7 @@
     </div>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/autosize.js/3.0.20/autosize.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/marked/4.2.12/marked.min.js"></script>
-    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/styles/default.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/styles/default.min.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/highlight.min.js"></script>
     <script src="https://cdn.socket.io/4.7.2/socket.io.min.js"
         integrity="sha384-mZLF4UVrpi/QTWPA7BjNPEnkIfRFn4ZEO3Qt/HFklTJBj/gBOV8G3HcKn4NfQblz"

--- a/widget/nginx-variables.conf
+++ b/widget/nginx-variables.conf
@@ -1,0 +1,1 @@
+set $FRAME_ANCESTORS "'none'"; # Space delimited urls allowed to iframe the widget. If set to https: (without single quotes) all https sites are allowed

--- a/widget/nginx-variables.conf
+++ b/widget/nginx-variables.conf
@@ -1,1 +1,4 @@
+set $PIRSCH_ENABLED "0"; # Set to "1" to allow Pirsch analytics requests. Set the `PIRSCH_KEY` in another file.
+set $API_HOST "api.webwhiz.ai";
+set $CONNECT "wss://${API_HOST} https://${API_HOST}"; # Urls allowed to be loaded from scripts. `http://localhost:3000 ws://localhost:3000` for development. `https: wss:` to allow any host in `baseUrl=` param.
 set $FRAME_ANCESTORS "'none'"; # Space delimited urls allowed to iframe the widget. If set to https: (without single quotes) all https sites are allowed

--- a/widget/nginx.conf
+++ b/widget/nginx.conf
@@ -3,8 +3,18 @@ server {
 
   listen 80;
 
+  set $DEFAULT "default-src 'none'";
+  set $IMG "img-src 'self'";
+  set $STYLE "style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com";
+  set $SCRIPT "script-src 'self' 'unsafe-inline' https://cdn.socket.io https://cdnjs.cloudflare.com";
+  set $CONNECT "connect-src 'self' ${CONNECT}";
+  if ($PIRSCH_ENABLED) {
+    set $SCRIPT "${SCRIPT} https://api.pirsch.io";
+    set $CONNECT "${CONNECT} https://api.pirsch.io";
+  }
+
   set $FRAME_ANCESTORS "frame-ancestors ${FRAME_ANCESTORS}";
-  add_header Content-Security-Policy "${FRAME_ANCESTORS}" always;
+  add_header Content-Security-Policy "${DEFAULT}; ${IMG}; ${STYLE}; ${SCRIPT}; ${CONNECT}; ${FRAME_ANCESTORS}" always;
 
   location / {
     root /usr/share/nginx/html/;

--- a/widget/nginx.conf
+++ b/widget/nginx.conf
@@ -1,5 +1,10 @@
 server {
+  include /etc/nginx/nginx-variables.conf;
+
   listen 80;
+
+  set $FRAME_ANCESTORS "frame-ancestors ${FRAME_ANCESTORS}";
+  add_header Content-Security-Policy "${FRAME_ANCESTORS}" always;
 
   location / {
     root /usr/share/nginx/html/;


### PR DESCRIPTION
Improves on #225 (PR set as draft, to wait for the other PR to be merged)

Restrict the hosts that the widget is allowed to contact.

Also, set stylesheet from cloudflare to be loaded over https, also in
development.